### PR TITLE
added devServer config inside vue.config.js

### DIFF
--- a/client/vue.config.js
+++ b/client/vue.config.js
@@ -2,4 +2,12 @@ module.exports = {
   transpileDependencies: [
     'vuetify',
   ],
+  devServer: {
+    proxy: {
+      '^/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: true
+      },
+    }
+  }
 };


### PR DESCRIPTION
```
module.exports = {
  transpileDependencies: [
    'vuetify',
  ],
  devServer: {
    proxy: {
      '^/api': {
        target: 'http://localhost:3000',
        changeOrigin: true
      },
    }
  }
};
```

This config redirects /api routes to localhost:3000 where nodejs API is running

based on reference sent by Dan: https://medium.com/bb-tutorials-and-thoughts/how-to-develop-and-build-vue-js-app-with-nodejs-bd86feec1a20